### PR TITLE
Modify Anime Controller POST endpoint to enable Reactive Programming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
-HELP.md
 target/
 .mvn/wrapper/maven-wrapper.jar
 **/src/main/**/target/
 **/src/test/**/target/
 **/src/main/resources/application-local.yml
 .DS_Store
-*.sql
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Favourites List API
+This project is the back-end server that retrieves my lists of favourite things for the front-end client.
+
+### Things to note
+If you wish to run this project locally, you will need to do the following:
+
+* [Setup Postgres instance of favourites_list DB using Docker](https://www.docker.com/blog/how-to-use-the-postgres-docker-official-image/)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0</version>
+		<version>3.4.1</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.kumakun</groupId>
@@ -13,46 +13,43 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Favourites List API</name>
 	<description>Spring Boot REST API for retrieval of my favourites list</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>21</java.version>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-simple</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-to-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
+			<artifactId>spring-boot-starter-data-r2dbc</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
+			<artifactId>r2dbc-postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -67,6 +64,38 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-resolver-dns-native-macos</artifactId>
+			<scope>runtime</scope>
+			<classifier>osx-aarch_64</classifier>
+			<version>4.1.116.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.24.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.24.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.24.3</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.36</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -75,7 +104,29 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<argLine>
+						<!--Study plugins and jars more-->
+						-javaagent:"${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"
+						-Xshare:off
+					</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/com/kumakun/favouriteslist/FavouritesListApplication.java
+++ b/src/main/java/com/kumakun/favouriteslist/FavouritesListApplication.java
@@ -2,8 +2,10 @@ package com.kumakun.favouriteslist;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 
 @SpringBootApplication
+@EnableR2dbcRepositories
 public class FavouritesListApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kumakun/favouriteslist/client/dto/JikanResponseDTO.java
+++ b/src/main/java/com/kumakun/favouriteslist/client/dto/JikanResponseDTO.java
@@ -1,21 +1,15 @@
 package com.kumakun.favouriteslist.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
 import java.util.List;
 
-@Getter
-@Setter
-@AllArgsConstructor
+@Data
 public class JikanResponseDTO {
-    public List<AnimeData> data;
+    private List<AnimeData> data;
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
+    @Data
     public static class AnimeData {
         private String title;
         private Images images;
@@ -24,16 +18,12 @@ public class JikanResponseDTO {
         private String url;
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
+    @Data
     public static class Images {
         private Jpg jpg;
     }
 
-    @Getter
-    @Setter
-    @AllArgsConstructor
+    @Data
     public static class Jpg {
         @JsonProperty("large_image_url")
         private String largeImageUrl;

--- a/src/main/java/com/kumakun/favouriteslist/controller/AnimeController.java
+++ b/src/main/java/com/kumakun/favouriteslist/controller/AnimeController.java
@@ -1,6 +1,7 @@
 package com.kumakun.favouriteslist.controller;
 
 import com.kumakun.favouriteslist.dto.AnimeDTO;
+import com.kumakun.favouriteslist.model.Anime;
 import com.kumakun.favouriteslist.service.AnimeService;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
@@ -25,8 +27,8 @@ public class AnimeController {
     }
 
     @GetMapping
-    public Mono<List<AnimeDTO>> getAllFavouriteAnime() {
-        return animeService.retrieveAnimeList();
+    public Flux<Anime> getAllFavouriteAnime() {
+        return animeService.fetchAnimeList();
     }
 
     @PostMapping

--- a/src/main/java/com/kumakun/favouriteslist/dto/AnimeDTO.java
+++ b/src/main/java/com/kumakun/favouriteslist/dto/AnimeDTO.java
@@ -4,9 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+@AllArgsConstructor
 @Getter
 @Setter
-@AllArgsConstructor
 public class AnimeDTO {
     private String title;
     private String imageUrl;

--- a/src/main/java/com/kumakun/favouriteslist/model/Anime.java
+++ b/src/main/java/com/kumakun/favouriteslist/model/Anime.java
@@ -1,36 +1,37 @@
 package com.kumakun.favouriteslist.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.data.relational.core.mapping.Column;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.UUID;
 
-@Entity
-@Data
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 @Builder
-@Table(name = "anime")
-public class Anime {
+@Getter
+@Setter
+public class Anime implements Persistable<UUID> {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
-    @Column(nullable = false, unique = true)
     private String title;
-    @Column(nullable = false, name = "image_url")
+    @Column("image_url")
     private String imageUrl;
-    @Column(nullable = false, length = 4000)
     private String synopsis;
-    @Column (nullable = false)
     private int episodes;
-    @Column (nullable = false)
     private String url;
+
+    @Transient
+    @Builder.Default
+    private boolean isNewEntry = true;
+
+    public boolean isNew() {
+        return isNewEntry;
+    }
 }

--- a/src/main/java/com/kumakun/favouriteslist/repository/AnimeRepository.java
+++ b/src/main/java/com/kumakun/favouriteslist/repository/AnimeRepository.java
@@ -1,7 +1,7 @@
 package com.kumakun.favouriteslist.repository;
 
 import com.kumakun.favouriteslist.model.Anime;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,6 +11,6 @@ import java.util.UUID;
  * Service interface for anime list.
  */
 @Repository
-public interface AnimeRepository extends JpaRepository<Anime, UUID> {
+public interface AnimeRepository extends ReactiveCrudRepository<Anime, UUID> {
     Optional<Anime> findByTitle(String title);
 }

--- a/src/main/java/com/kumakun/favouriteslist/service/AnimeService.java
+++ b/src/main/java/com/kumakun/favouriteslist/service/AnimeService.java
@@ -2,19 +2,19 @@ package com.kumakun.favouriteslist.service;
 
 import com.kumakun.favouriteslist.dto.AnimeDTO;
 import com.kumakun.favouriteslist.model.Anime;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 public interface AnimeService {
     /**
-     * Retrieves list of anime for client.
-     * @return list of anime for client
-     */
-    Mono<List<AnimeDTO>> retrieveAnimeList();
-
+     * Make asynchronous calls to Jikan's MyAnimeList API to retrieve details
+     * on anime in submitted list and save to database.
+     * @param animeTitles - List of anime titles to be added to database
+     * @return Details of anime saved to database
+     * */
     Mono<List<AnimeDTO>> addAnimeList(List<String> animeTitles);
 
     /**
@@ -22,23 +22,23 @@ public interface AnimeService {
      * @param title the anime title to search by
      * @return the saved anime
      */
-    Optional<Anime> findAnimeByTitle(String title);
+    Anime findAnimeByTitle(String title);
 
     /**
      * Saves an anime entity.
      * @param anime the anime to save
      */
-    Anime saveAnime(Anime anime);
+    Mono<Anime> saveAnime(Anime anime);
 
     /**
      * Fetches the list of all anime entities.
      * @return a list of anime
      */
-    List<Anime> fetchAnimeList();
+    Flux<Anime> fetchAnimeList();
 
     /**
      * Deletes an anime entity by its ID.
      * @param id the ID of the anime to delete
      */
-    void deleteAnimeByUuid(UUID id);
+    Mono<Void> deleteAnimeByUuid(UUID id);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,24 +3,11 @@ spring:
     active: local # Development is ongoing
   application:
     name: favouriteslist
-  jpa:
-    database: POSTGRESQL
-    show-sql: true
-    hibernate:
-      ddl-auto: none
-    properties:
-      jakarta:
-        persistence:
-          schema-generation:
-            scripts:
-              action: none
-              create-target: create.sql
-              create-source: metadata
-jakarta:
-  persistence:
-    schema-generation:
-      create-source: metadata
-      drop-source: metadata
+  sql:
+    init:
+      mode: always # ensure DB script is constructed to generate table only once
+      schema-locations: optional:classpath:schema.sql
+      data-locations: optional:classpath:data.sql
 jikan:
   api:
     url: "https://api.jikan.moe/v4"

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+    <Properties>
+        <Property name="LOG_PATTERN">%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT" follow="true">
+            <PatternLayout pattern="${LOG_PATTERN}"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS anime (
+    id UUID PRIMARY KEY,
+    title VARCHAR(100),
+    image_url VARCHAR(255),
+    synopsis TEXT,
+    episodes INT,
+    url VARCHAR(255)
+);


### PR DESCRIPTION
The use of Spring WebFlux requires a specific approach to its inclusion in a project. Previously, there was an attempt to use blocking I/O operations with the use of JPA in order to interact with the PostgreSQL database and store anime details retrieved from Jikan.

While JPA can be utilized with WebFlux it can lead to issues due to its blocking nature. WebFlux is centred on the Reactive Programming paradigm which works best with non-blocking I/O operations. The use of R2DBC and ReactiveCrudRepository adds assurance that interactions with the database will adhere to the principles of the paradigm.

The project was further cleaned up of unnecessary annotations and dependencies and effective logging was added to track successful and erroneous execution throughout the service layer of the project.